### PR TITLE
Downgrade Go version requirement to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/kataras/jwt
 
-go 1.21
+go 1.20


### PR DESCRIPTION
As part of the upgrade to Go 1.21, the Go toolchain now requires the
`go` directive to match the maximum Go version in use in dependencies.

This leads to any transitive dependency on this library to result in a
requirement of the consuming project moving to Go 1.21.

Although in a lot of cases this may not be as problematic, it forces
consumers to migrate, which we don't need to do in this case.

---


As discussed in https://github.com/deepmap/oapi-codegen/issues/1221 and related change in https://github.com/gofiber/fiber/pull/2614. See also https://github.com/golang/go/issues/62409